### PR TITLE
fix: index San Francisco in timezone search

### DIFF
--- a/apps/web-app/src/components/main.tsx
+++ b/apps/web-app/src/components/main.tsx
@@ -14,7 +14,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { TimezoneSearch } from '@/components/timezone-search';
 import { cn } from '@/lib/utils';
 import { SettingsDialog } from '@/components/settings-dialog';
-import { TimeZoneInfo, findTimezone, findTimezoneByIana, getTimeInTimeZone } from '@/lib/timezone';
+import { TimeZoneInfo, findTimezone, findTimezoneByIana, getTimeInTimeZone, locationToSlug } from '@/lib/timezone';
 import { TimelineSettings } from '@/lib/types';
 import { EmptyState } from '@/components/empty-state';
 import { AppFooter } from '@/components/app-footer';
@@ -35,7 +35,7 @@ export function Main() {
   const [isEditMode, setIsEditMode] = useState(false);
   const searchTriggerRef = useRef<HTMLButtonElement>(null);
   const hasDetectedTimezone = useRef(false);
-  
+
   // Initialize timezones from URL
   const [timeZones, setTimeZones] = useState<TimeZoneInfo[]>(() => {
     const ianaNames = searchParams.get('z')?.split(',') || [];
@@ -59,16 +59,16 @@ export function Main() {
       try {
         const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
         const timezoneInfo = findTimezoneByIana(userTimezone);
-        
+
         if (timezoneInfo) {
           hasDetectedTimezone.current = true;
           const timezoneWithTime = {
             ...timezoneInfo,
             ...getTimeInTimeZone(new Date(), timezoneInfo.ianaName)
           };
-          
+
           setTimeZones([timezoneWithTime]);
-          
+
           // Track timezone auto-detection
           if (posthog) {
             trackEvent(posthog, EventCategory.TIMEZONE, EventAction.ADD, {
@@ -87,13 +87,13 @@ export function Main() {
   // Initialize timeline settings from URL
   const [timelineSettings, setTimelineSettings] = useState<TimelineSettings>(() => {
     const blockedParam = searchParams.get('b');
-    const blockedTimeSlots = blockedParam 
+    const blockedTimeSlots = blockedParam
       ? blockedParam.split(',').map(block => {
           const [start, end] = block.split('-').map(Number);
           return { start, end };
         })
       : [{ start: 22, end: 6 }];
-    
+
     return {
       blockedTimeSlots,
       defaultBlockedHours: blockedTimeSlots[0],
@@ -104,7 +104,7 @@ export function Main() {
   // Update times every minute and when selectedDate changes
   useEffect(() => {
     const updateTimes = () => {
-      setTimeZones(prevZones => 
+      setTimeZones(prevZones =>
         prevZones.map(tz => ({
           ...tz,
           ...getTimeInTimeZone(selectedDate, tz.ianaName)
@@ -121,34 +121,39 @@ export function Main() {
     return () => clearInterval(interval);
   }, [selectedDate]);
 
-  // Update URL when timezones or blocked hours change
-  useEffect(() => {
-    const zParam = timeZones.map(tz => tz.ianaName).join(',');
-    const bParam = timelineSettings.blockedTimeSlots
+  const timezoneUrlParam = useMemo(() => {
+    return timeZones
+      .map(tz => tz.urlSlug || locationToSlug(tz.name || tz.label) || tz.ianaName)
+      .join(',');
+  }, [timeZones]);
+
+  const blockedHoursUrlParam = useMemo(() => {
+    return timelineSettings.blockedTimeSlots
       .map(slot => `${slot.start}-${slot.end}`)
       .join(',');
-    
-    const url = zParam 
-      ? `/?z=${zParam}&b=${bParam}`
-      : `/?b=${bParam}`;
-    
+  }, [timelineSettings.blockedTimeSlots]);
+
+  // Update URL when timezones or blocked hours change
+  useEffect(() => {
+    const url = timezoneUrlParam
+      ? `/?z=${timezoneUrlParam}&b=${blockedHoursUrlParam}`
+      : `/?b=${blockedHoursUrlParam}`;
+
     router.push(url);
-  }, [timeZones.map(tz => tz.ianaName).join(','), // Only trigger on timezone list changes
-      timelineSettings.blockedTimeSlots.map(slot => `${slot.start}-${slot.end}`).join(','), // Only trigger on blocked hours changes
-      router]);
+  }, [timezoneUrlParam, blockedHoursUrlParam, router]);
 
   // Handle keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Skip if user is typing in an input field
       if (
-        e.target instanceof HTMLInputElement || 
+        e.target instanceof HTMLInputElement ||
         e.target instanceof HTMLTextAreaElement ||
         e.target instanceof HTMLSelectElement
       ) {
         return;
       }
-      
+
       // Handle keyboard shortcuts
       if (e.key.toLowerCase() === 'e' && view === 'cards') {
         handleToggleEditMode();
@@ -165,10 +170,10 @@ export function Main() {
         }
       }
     };
-    
+
     // Add event listener
     document.addEventListener('keydown', handleKeyDown);
-    
+
     // Clean up
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
@@ -178,7 +183,7 @@ export function Main() {
   // Get blocked hours for grid view
   const blockedHours = useMemo(() => {
     const blocks: BlockedHours = {};
-    
+
     timeZones.forEach(tz => {
       blocks[tz.ianaName] = [];
       timelineSettings.blockedTimeSlots.forEach(slot => {
@@ -208,7 +213,7 @@ export function Main() {
     if (date) {
       setSelectedDate(date);
       // Update all timezone times when date changes
-      setTimeZones(prevZones => 
+      setTimeZones(prevZones =>
         prevZones.map(tz => ({
           ...tz,
           ...getTimeInTimeZone(date, tz.ianaName)
@@ -221,7 +226,7 @@ export function Main() {
   const handleTimeChange = (newDate: Date) => {
     setSelectedDate(newDate);
     // Update all timezone times when time changes
-    setTimeZones(prevZones => 
+    setTimeZones(prevZones =>
       prevZones.map(tz => ({
         ...tz,
         ...getTimeInTimeZone(newDate, tz.ianaName)
@@ -244,14 +249,14 @@ export function Main() {
         ...getTimeInTimeZone(selectedDate, timezone.ianaName)
       };
       const updatedZones = [...prev, updatedZone];
-      
+
       // Track timezone added
       trackEvent(posthog, EventCategory.TIMEZONE, EventAction.ADD, {
         timezone: timezone.ianaName,
         total_count: updatedZones.length,
         view
       });
-      
+
       return updatedZones;
     });
   };
@@ -259,14 +264,14 @@ export function Main() {
   const handleRemoveTimeZone = (ianaName: string) => {
     setTimeZones(prev => {
       const updatedZones = prev.filter(tz => tz.ianaName !== ianaName);
-      
+
       // Track timezone removed
       trackEvent(posthog, EventCategory.TIMEZONE, EventAction.REMOVE, {
         timezone: ianaName,
         total_count: updatedZones.length,
         view
       });
-      
+
       return updatedZones;
     });
   };
@@ -275,26 +280,26 @@ export function Main() {
     setTimeZones(prev => {
       // First sort by UTC offset
       const sortedZones = [...prev].sort((a, b) => a.utcOffset - b.utcOffset);
-      
+
       // Then update times for all sorted zones
       const updatedSortedZones = sortedZones.map(tz => ({
         ...tz,
         ...getTimeInTimeZone(selectedDate, tz.ianaName)
       }));
-      
+
       // Track timezone sorting
       trackEvent(posthog, EventCategory.TIMEZONE, EventAction.SORT, {
         count: updatedSortedZones.length,
         view
       });
-      
+
       return updatedSortedZones;
     });
   };
 
   const handleSettingsChange = (settings: TimelineSettings) => {
     setTimelineSettings(settings);
-    
+
     // Track settings change
     trackEvent(posthog, EventCategory.BLOCKED_HOURS, EventAction.UPDATE, {
       count: settings.blockedTimeSlots.length,
@@ -342,7 +347,7 @@ export function Main() {
         <div className="bg-gradient-to-r from-gray-50 to-white p-6 rounded-2xl border border-gray-100 mb-8">
           <div className="flex flex-col sm:flex-row sm:items-center gap-4">
             <div className="flex-1 min-w-0">
-              <TimezoneSearch 
+              <TimezoneSearch
                 onSelect={handleAddTimeZone}
                 selectedTimezones={timeZones.map(tz => tz.ianaName)}
                 triggerRef={searchTriggerRef}
@@ -352,8 +357,8 @@ export function Main() {
               <div className="relative z-40">
               <Popover open={isCalendarOpen} onOpenChange={setIsCalendarOpen}>
                 <PopoverTrigger asChild>
-                  <Button 
-                    variant="outline" 
+                  <Button
+                    variant="outline"
                     className={cn(
                       "transition-colors shrink-0",
                       "md:w-40",
@@ -365,9 +370,9 @@ export function Main() {
                     <span className="hidden md:inline">{format(selectedDate, 'MMM dd, yyyy')}</span>
                   </Button>
                 </PopoverTrigger>
-                <PopoverContent 
-                  className="w-auto p-0" 
-                  align="end" 
+                <PopoverContent
+                  className="w-auto p-0"
+                  align="end"
                   sideOffset={4}
                   onOpenAutoFocus={(e) => {
                     if (window.innerWidth < 640) {
@@ -391,9 +396,9 @@ export function Main() {
               </Popover>
               </div>
               <div className="flex gap-2">
-              <Button 
-                variant="ghost" 
-                size="icon" 
+              <Button
+                variant="ghost"
+                size="icon"
                 onClick={handleSort}
                 title="Sort by timezone offset (S)"
                 className="shrink-0"
@@ -401,13 +406,13 @@ export function Main() {
                 <ArrowsUpDownIcon className="h-5 w-5" />
                 <span className="sr-only">Sort timezones</span>
               </Button>
-              <SettingsDialog 
+              <SettingsDialog
                 settings={timelineSettings}
                 onSettingsChange={handleSettingsChange}
                 timeZones={timeZones.map(tz => ({ name: tz.name, ianaName: tz.ianaName }))}
               />
               {view === 'cards' && (
-                <Button 
+                <Button
                   variant={isEditMode ? "default" : "ghost"}
                   size="icon"
                   onClick={handleToggleEditMode}
@@ -428,7 +433,7 @@ export function Main() {
           {timeZones.length === 0 ? (
             <EmptyState onAddTimezone={() => searchTriggerRef.current?.click()} />
           ) : view === 'cards' ? (
-          <TimelineView 
+          <TimelineView
             timeZones={timeZones}
             selectedDate={selectedDate}
             onTimeChange={handleTimeChange}
@@ -444,9 +449,9 @@ export function Main() {
           />
           )}
         </div>
-        
+
         <AppFooter />
       </div>
     </main>
   );
-} 
+}

--- a/apps/web-app/src/components/main.tsx
+++ b/apps/web-app/src/components/main.tsx
@@ -14,7 +14,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { TimezoneSearch } from '@/components/timezone-search';
 import { cn } from '@/lib/utils';
 import { SettingsDialog } from '@/components/settings-dialog';
-import { TimeZoneInfo, findTimezoneByIana, getTimeInTimeZone } from '@/lib/timezone';
+import { TimeZoneInfo, findTimezone, findTimezoneByIana, getTimeInTimeZone } from '@/lib/timezone';
 import { TimelineSettings } from '@/lib/types';
 import { EmptyState } from '@/components/empty-state';
 import { AppFooter } from '@/components/app-footer';
@@ -40,7 +40,7 @@ export function Main() {
   const [timeZones, setTimeZones] = useState<TimeZoneInfo[]>(() => {
     const ianaNames = searchParams.get('z')?.split(',') || [];
     return ianaNames
-      .map(name => findTimezoneByIana(name))
+      .map(name => findTimezone(name))
       .filter((tz): tz is TimeZoneInfo => tz !== undefined)
       .map(tz => ({
         ...tz,

--- a/apps/web-app/src/components/timezone-search.tsx
+++ b/apps/web-app/src/components/timezone-search.tsx
@@ -43,7 +43,7 @@ const TimezoneItem = React.memo(({
   isSelected: boolean;
 }) => (
   <CommandItem
-    value={`${timezone.label} ${(timezone.aliases || []).join(' ')} ${timezone.country}`}
+    value={`${timezone.label} ${timezone.ianaName} ${(timezone.aliases || []).join(' ')} ${timezone.country}`}
     onSelect={() => onSelect(timezone.ianaName)}
     disabled={isSelected}
     className={isSelected ? 'opacity-50 cursor-not-allowed' : ''}

--- a/apps/web-app/src/components/timezone-search.tsx
+++ b/apps/web-app/src/components/timezone-search.tsx
@@ -16,6 +16,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { PlusIcon, CheckIcon } from "@heroicons/react/24/outline"
 import { TimeZoneInfo, timezoneDatabase } from "@/lib/timezone"
+import { searchTimezones } from "@/lib/timezone-search"
 import { getRecentTimezones } from "@/lib/utils"
 
 // Debug mode flag - set to true to show debug panel
@@ -42,7 +43,7 @@ const TimezoneItem = React.memo(({
   isSelected: boolean;
 }) => (
   <CommandItem
-    value={`${timezone.label} ${timezone.country}`}
+    value={`${timezone.label} ${(timezone.aliases || []).join(' ')} ${timezone.country}`}
     onSelect={() => onSelect(timezone.ianaName)}
     disabled={isSelected}
     className={isSelected ? 'opacity-50 cursor-not-allowed' : ''}
@@ -54,6 +55,11 @@ const TimezoneItem = React.memo(({
         )}
         <span className="flex flex-col">
           <span>{timezone.label}</span>
+          {timezone.aliases && timezone.aliases.length > 0 && (
+            <span className="text-xs text-muted-foreground">
+              Also: {timezone.aliases.join(', ')}
+            </span>
+          )}
           <span className="text-xs text-muted-foreground">
             {timezone.country} {timezone.countryCode ? `(${timezone.countryCode})` : ''}
           </span>
@@ -129,68 +135,15 @@ export function TimezoneSearch({ onSelect, selectedTimezones = [], triggerRef }:
       return availableTimezones;
     }
     
-    // Clean up search input but keep spaces for matching
-    const searchTerms = search.toLowerCase().trim().split(/\s+/).filter(Boolean);
-    if (searchTerms.length === 0) {
-      return availableTimezones;
-    }
-
-    // First try to find exact matches
-    const exactMatches = availableTimezones.filter(tz => {
-      const cityName = tz.label.toLowerCase();
-      return cityName === searchTerms.join(' ');
-    });
-
-    if (exactMatches.length > 0) {
-      // Log first 5 exact matches
-      if (DEBUG_MODE) {
-        console.log('Exact matches for:', search);
-        console.log(exactMatches.slice(0, 5).map(tz => `${tz.label}, ${tz.country} (${tz.ianaName})`));
-      }
-      return exactMatches;
-    }
-
-    // Then try to find partial matches where all terms are included
-    const partialMatches = availableTimezones.filter(tz => {
-      const searchableText = [
-        tz.label.toLowerCase(),
-        tz.country.toLowerCase(),
-        tz.countryCode.toLowerCase(),
-      ].join(' ');
-
-      return searchTerms.every(term => searchableText.includes(term));
-    });
-
-    if (partialMatches.length > 0) {
-      // Log first 5 partial matches
-      if (DEBUG_MODE) {
-        console.log('Partial matches for:', search);
-        console.log(partialMatches.slice(0, 5).map(tz => `${tz.label}, ${tz.country} (${tz.ianaName})`));
-      }
-      return partialMatches;
-    }
-
-    // Finally, try broader matches where any term matches
-    const broadMatches = availableTimezones.filter(tz => {
-      const searchableText = [
-        tz.label.toLowerCase(),
-        tz.region.toLowerCase(),
-        tz.country.toLowerCase(),
-        tz.countryCode.toLowerCase(),
-        tz.timezone.toLowerCase(),
-        tz.ianaName.toLowerCase()
-      ].join(' ');
-
-      return searchTerms.some(term => searchableText.includes(term));
-    });
+    const matches = searchTimezones(availableTimezones, search);
     
     // Log first 5 broad matches
     if (DEBUG_MODE) {
       console.log('Broad matches for:', search);
-      console.log(broadMatches.slice(0, 5).map(tz => `${tz.label}, ${tz.country} (${tz.ianaName})`));
+      console.log(matches.slice(0, 5).map(tz => `${tz.label}, ${tz.country} (${tz.ianaName})`));
     }
     
-    return broadMatches;
+    return matches;
   }, [availableTimezones, search]);
 
   // Get recent timezones for debug panel
@@ -351,4 +304,4 @@ export function TimezoneSearch({ onSelect, selectedTimezones = [], triggerRef }:
       )}
     </>
   )
-} 
+}

--- a/apps/web-app/src/components/timezone-search.tsx
+++ b/apps/web-app/src/components/timezone-search.tsx
@@ -17,7 +17,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 
-import { TimeZoneInfo, timezoneDatabase } from "@/lib/timezone";
+import { TimeZoneInfo, timezoneDatabase, withDisplayLocation } from "@/lib/timezone";
 import { searchTimezones } from "@/lib/timezone-search";
 import { getRecentTimezones } from "@/lib/utils";
 
@@ -81,7 +81,7 @@ const TimezoneItem = React.memo(
     return (
       <CommandItem
         value={`${city} ${timezone.label} ${timezone.ianaName} ${timezone.country}`}
-        onSelect={() => onSelect(timezone.ianaName)}
+        onSelect={() => onSelect(cityResult.id)}
         disabled={isSelected}
         className={isSelected ? "cursor-not-allowed opacity-50" : ""}
       >
@@ -253,10 +253,17 @@ export function TimezoneSearch({
       if (!value || value === lastSelected) return;
 
       try {
+        const [ianaName, ...cityParts] = value.split(":");
         const selectedTimezone = timezoneDatabase.find(
-          (tz) => tz.ianaName === value,
+          (tz) => tz.ianaName === ianaName,
         );
         if (!selectedTimezone) return;
+
+        const selectedCity = cityParts.join(":") || selectedTimezone.label;
+        const displayedTimezone = withDisplayLocation(
+          selectedTimezone,
+          selectedCity,
+        );
 
         // Update state in a more controlled way
         setLastSelected(value);
@@ -264,7 +271,7 @@ export function TimezoneSearch({
         setOpen(false); // Close popover after selection
         // Use requestAnimationFrame to ensure state updates are processed before callback
         requestAnimationFrame(() => {
-          onSelect(selectedTimezone);
+          onSelect(displayedTimezone);
         });
       } catch (error) {
         // Silent error handling

--- a/apps/web-app/src/components/timezone-search.tsx
+++ b/apps/web-app/src/components/timezone-search.tsx
@@ -1,4 +1,7 @@
-import * as React from "react"
+import { PlusIcon, CheckIcon } from "@heroicons/react/24/outline";
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
 import {
   Command,
   CommandEmpty,
@@ -7,17 +10,16 @@ import {
   CommandItem,
   CommandList,
   CommandSeparator,
-} from "@/components/ui/command"
+} from "@/components/ui/command";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@/components/ui/popover"
-import { Button } from "@/components/ui/button"
-import { PlusIcon, CheckIcon } from "@heroicons/react/24/outline"
-import { TimeZoneInfo, timezoneDatabase } from "@/lib/timezone"
-import { searchTimezones } from "@/lib/timezone-search"
-import { getRecentTimezones } from "@/lib/utils"
+} from "@/components/ui/popover";
+
+import { TimeZoneInfo, timezoneDatabase } from "@/lib/timezone";
+import { searchTimezones } from "@/lib/timezone-search";
+import { getRecentTimezones } from "@/lib/utils";
 
 // Debug mode flag - set to true to show debug panel
 const DEBUG_MODE = false;
@@ -28,103 +30,142 @@ interface TimezoneSearchProps {
   triggerRef?: React.RefObject<HTMLButtonElement>;
 }
 
+interface TimezoneCityResult {
+  id: string;
+  timezone: TimeZoneInfo;
+  city: string;
+}
+
 interface GroupedTimezones {
-  [key: string]: TimeZoneInfo[];
+  [key: string]: TimezoneCityResult[];
+}
+
+function normalizeSearchText(value: string): string {
+  return value.toLowerCase().trim();
+}
+
+function getCityRows(
+  timezone: TimeZoneInfo,
+  search: string,
+): TimezoneCityResult[] {
+  const cities = [timezone.label, ...(timezone.aliases || [])];
+  const normalizedSearch = normalizeSearchText(search);
+  const matchingCities = normalizedSearch
+    ? cities.filter((city) =>
+        normalizeSearchText(city).includes(normalizedSearch),
+      )
+    : cities;
+
+  const visibleCities = matchingCities.length > 0 ? matchingCities : cities;
+
+  return visibleCities.map((city) => ({
+    id: `${timezone.ianaName}:${city}`,
+    timezone,
+    city,
+  }));
 }
 
 // Memoized timezone item component
-const TimezoneItem = React.memo(({ 
-  timezone, 
-  onSelect,
-  isSelected
-}: { 
-  timezone: TimeZoneInfo; 
-  onSelect: (value: string) => void;
-  isSelected: boolean;
-}) => (
-  <CommandItem
-    value={`${timezone.label} ${timezone.ianaName} ${(timezone.aliases || []).join(' ')} ${timezone.country}`}
-    onSelect={() => onSelect(timezone.ianaName)}
-    disabled={isSelected}
-    className={isSelected ? 'opacity-50 cursor-not-allowed' : ''}
-  >
-    <span className="flex items-center justify-between w-full">
-      <span className="flex items-center gap-2">
-        {isSelected && (
-          <CheckIcon className="h-4 w-4 text-muted-foreground" />
-        )}
-        <span className="flex flex-col">
-          <span>{timezone.label}</span>
-          {timezone.aliases && timezone.aliases.length > 0 && (
-            <span className="text-xs text-muted-foreground">
-              Also: {timezone.aliases.join(', ')}
+const TimezoneItem = React.memo(
+  ({
+    cityResult,
+    onSelect,
+    isSelected,
+  }: {
+    cityResult: TimezoneCityResult;
+    onSelect: (value: string) => void;
+    isSelected: boolean;
+  }) => {
+    const { timezone, city } = cityResult;
+
+    return (
+      <CommandItem
+        value={`${city} ${timezone.label} ${timezone.ianaName} ${timezone.country}`}
+        onSelect={() => onSelect(timezone.ianaName)}
+        disabled={isSelected}
+        className={isSelected ? "cursor-not-allowed opacity-50" : ""}
+      >
+        <span className="flex w-full items-center justify-between">
+          <span className="flex items-center gap-2">
+            {isSelected && (
+              <CheckIcon className="text-muted-foreground h-4 w-4" />
+            )}
+            <span className="flex flex-col">
+              <span>{city}</span>
+              <span className="text-muted-foreground text-xs">
+                {timezone.country}{" "}
+                {timezone.countryCode ? `(${timezone.countryCode})` : ""}
+              </span>
             </span>
-          )}
-          <span className="text-xs text-muted-foreground">
-            {timezone.country} {timezone.countryCode ? `(${timezone.countryCode})` : ''}
+          </span>
+          <span className="text-muted-foreground ml-2 text-xs">
+            {timezone.timezone}
           </span>
         </span>
-      </span>
-      <span className="text-xs text-muted-foreground ml-2">
-        {timezone.timezone}
-      </span>
-    </span>
-  </CommandItem>
-));
+      </CommandItem>
+    );
+  },
+);
 
-TimezoneItem.displayName = 'TimezoneItem';
+TimezoneItem.displayName = "TimezoneItem";
 
 // Memoized timezone group component
-const TimezoneGroup = React.memo(({ 
-  region, 
-  timezones,
+const TimezoneGroup = React.memo(
+  ({
+    region,
+    timezones,
+    onSelect,
+    selectedTimezones,
+  }: {
+    region: string;
+    timezones: TimezoneCityResult[];
+    onSelect: (value: string) => void;
+    selectedTimezones: string[];
+  }) => (
+    <CommandGroup heading={region}>
+      {timezones.map((timezone) => (
+        <TimezoneItem
+          key={timezone.id}
+          cityResult={timezone}
+          onSelect={onSelect}
+          isSelected={selectedTimezones.includes(timezone.timezone.ianaName)}
+        />
+      ))}
+    </CommandGroup>
+  ),
+);
+
+TimezoneGroup.displayName = "TimezoneGroup";
+
+export function TimezoneSearch({
   onSelect,
-  selectedTimezones
-}: { 
-  region: string; 
-  timezones: TimeZoneInfo[];
-  onSelect: (value: string) => void;
-  selectedTimezones: string[];
-}) => (
-  <CommandGroup heading={region}>
-    {timezones.map((timezone) => (
-      <TimezoneItem
-        key={timezone.ianaName}
-        timezone={timezone}
-        onSelect={onSelect}
-        isSelected={selectedTimezones.includes(timezone.ianaName)}
-      />
-    ))}
-  </CommandGroup>
-));
-
-TimezoneGroup.displayName = 'TimezoneGroup';
-
-export function TimezoneSearch({ onSelect, selectedTimezones = [], triggerRef }: TimezoneSearchProps) {
+  selectedTimezones = [],
+  triggerRef,
+}: TimezoneSearchProps) {
   const [search, setSearch] = React.useState("");
   const [lastSelected, setLastSelected] = React.useState<string | null>(null);
   const [open, setOpen] = React.useState(false);
-  const [recentTimezones, setRecentTimezones] = React.useState<TimeZoneInfo[]>([]);
+  const [recentTimezones, setRecentTimezones] = React.useState<TimeZoneInfo[]>(
+    [],
+  );
 
-  const availableTimezones = React.useMemo(() => 
-    timezoneDatabase
-  , []);
+  const availableTimezones = React.useMemo(() => timezoneDatabase, []);
 
   // Load recent timezones
   React.useEffect(() => {
     if (open) {
       const recentIanaNames = getRecentTimezones();
-      
+
       // Filter out already selected timezones
       const filteredRecentNames = recentIanaNames.filter(
-        name => !selectedTimezones.includes(name)
+        (name) => !selectedTimezones.includes(name),
       );
-      
+
       // Convert IANA names to timezone objects
       const timezones = filteredRecentNames
-        .map(name => timezoneDatabase.find(tz => tz.ianaName === name))
+        .map((name) => timezoneDatabase.find((tz) => tz.ianaName === name))
         .filter((tz): tz is TimeZoneInfo => tz !== undefined);
-      
+
       setRecentTimezones(timezones);
     }
   }, [open, selectedTimezones]);
@@ -134,15 +175,19 @@ export function TimezoneSearch({ onSelect, selectedTimezones = [], triggerRef }:
     if (!search) {
       return availableTimezones;
     }
-    
+
     const matches = searchTimezones(availableTimezones, search);
-    
+
     // Log first 5 broad matches
     if (DEBUG_MODE) {
-      console.log('Broad matches for:', search);
-      console.log(matches.slice(0, 5).map(tz => `${tz.label}, ${tz.country} (${tz.ianaName})`));
+      console.log("Broad matches for:", search);
+      console.log(
+        matches
+          .slice(0, 5)
+          .map((tz) => `${tz.label}, ${tz.country} (${tz.ianaName})`),
+      );
     }
-    
+
     return matches;
   }, [availableTimezones, search]);
 
@@ -153,86 +198,111 @@ export function TimezoneSearch({ onSelect, selectedTimezones = [], triggerRef }:
 
   // Get filtered recent timezones for debug panel
   const filteredRecentTimezoneNames = React.useMemo(() => {
-    return recentTimezoneNames.filter(name => !selectedTimezones.includes(name));
+    return recentTimezoneNames.filter(
+      (name) => !selectedTimezones.includes(name),
+    );
   }, [recentTimezoneNames, selectedTimezones]);
 
   // Group timezones by region and sort by country
   const groupedTimezones = React.useMemo(() => {
     const groups: GroupedTimezones = {};
-    
+
+    const cityResults = filteredTimezones.flatMap((tz) =>
+      getCityRows(tz, search),
+    );
+
     // First group by region
-    filteredTimezones.forEach(tz => {
+    cityResults.forEach((result) => {
       // For country searches, group by country instead of region
-      const isCountrySearch = filteredTimezones.every(t => t.country === filteredTimezones[0].country);
-      const groupKey = isCountrySearch ? tz.country : tz.region;
-      
+      const isCountrySearch = filteredTimezones.every(
+        (t) => t.country === filteredTimezones[0].country,
+      );
+      const groupKey = isCountrySearch
+        ? result.timezone.country
+        : result.timezone.region;
+
       if (!groups[groupKey]) {
         groups[groupKey] = [];
       }
-      groups[groupKey].push(tz);
+      groups[groupKey].push(result);
     });
-    
+
     // Sort timezones within each group
-    Object.keys(groups).forEach(groupKey => {
+    Object.keys(groups).forEach((groupKey) => {
       groups[groupKey].sort((a, b) => {
         // If it's a country search, sort by city name only
-        if (a.country === b.country) {
-          return a.label.localeCompare(b.label);
+        if (a.timezone.country === b.timezone.country) {
+          return a.city.localeCompare(b.city);
         }
         // Otherwise, sort by country then city
-        const countryCompare = a.country.localeCompare(b.country);
-        return countryCompare !== 0 ? countryCompare : a.label.localeCompare(b.label);
+        const countryCompare = a.timezone.country.localeCompare(
+          b.timezone.country,
+        );
+        return countryCompare !== 0
+          ? countryCompare
+          : a.city.localeCompare(b.city);
       });
     });
-    
+
     return groups;
-  }, [filteredTimezones]);
+  }, [filteredTimezones, search]);
 
   // Memoize the handleSelect function
-  const handleSelect = React.useCallback((value: string) => {
-    if (!value || value === lastSelected) return;
-    
-    try {
-      const selectedTimezone = timezoneDatabase.find(tz => tz.ianaName === value);
-      if (!selectedTimezone) return;
+  const handleSelect = React.useCallback(
+    (value: string) => {
+      if (!value || value === lastSelected) return;
 
-      // Update state in a more controlled way
-      setLastSelected(value);
-      setSearch(""); // Reset search first
-      setOpen(false); // Close popover after selection
-      // Use requestAnimationFrame to ensure state updates are processed before callback
-      requestAnimationFrame(() => {
-        onSelect(selectedTimezone);
-      });
-    } catch (error) {
-      // Silent error handling
-    }
-  }, [onSelect, lastSelected]);
+      try {
+        const selectedTimezone = timezoneDatabase.find(
+          (tz) => tz.ianaName === value,
+        );
+        if (!selectedTimezone) return;
+
+        // Update state in a more controlled way
+        setLastSelected(value);
+        setSearch(""); // Reset search first
+        setOpen(false); // Close popover after selection
+        // Use requestAnimationFrame to ensure state updates are processed before callback
+        requestAnimationFrame(() => {
+          onSelect(selectedTimezone);
+        });
+      } catch (error) {
+        // Silent error handling
+      }
+    },
+    [onSelect, lastSelected],
+  );
 
   // Memoize the timezone groups rendering
-  const timezoneGroups = React.useMemo(() => (
-    Object.entries(groupedTimezones || {}).map(([region, timezones]) => (
-      <TimezoneGroup
-        key={region}
-        region={region}
-        timezones={timezones}
-        onSelect={handleSelect}
-        selectedTimezones={selectedTimezones}
-      />
-    ))
-  ), [groupedTimezones, handleSelect, selectedTimezones]);
+  const timezoneGroups = React.useMemo(
+    () =>
+      Object.entries(groupedTimezones || {}).map(([region, timezones]) => (
+        <TimezoneGroup
+          key={region}
+          region={region}
+          timezones={timezones}
+          onSelect={handleSelect}
+          selectedTimezones={selectedTimezones}
+        />
+      )),
+    [groupedTimezones, handleSelect, selectedTimezones],
+  );
 
   // Memoize the recent timezones rendering
   const recentTimezoneItems = React.useMemo(() => {
     if (recentTimezones.length === 0) return null;
-    
+
     return (
       <>
         <CommandGroup heading="Recent">
           {recentTimezones.map((timezone) => (
             <TimezoneItem
               key={`recent-${timezone.ianaName}`}
-              timezone={timezone}
+              cityResult={{
+                id: `recent-${timezone.ianaName}`,
+                timezone,
+                city: timezone.label,
+              }}
               onSelect={handleSelect}
               isSelected={selectedTimezones.includes(timezone.ianaName)}
             />
@@ -247,10 +317,10 @@ export function TimezoneSearch({ onSelect, selectedTimezones = [], triggerRef }:
     <>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <Button 
+          <Button
             ref={triggerRef}
-            variant="outline" 
-            role="combobox" 
+            variant="outline"
+            role="combobox"
             aria-expanded={open}
             className="w-full justify-between"
           >
@@ -258,14 +328,14 @@ export function TimezoneSearch({ onSelect, selectedTimezones = [], triggerRef }:
               <PlusIcon className="h-4 w-4" />
               Add Time Zone, City or Town...
             </span>
-            <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
+            <kbd className="bg-muted text-muted-foreground pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border px-1.5 font-mono text-[10px] font-medium opacity-100">
               <span className="text-xs">K</span>
             </kbd>
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-[400px] p-0" align="start">
           <Command className="rounded-lg border-0">
-            <CommandInput 
+            <CommandInput
               placeholder="Search timezone..."
               value={search}
               onValueChange={setSearch}
@@ -280,22 +350,28 @@ export function TimezoneSearch({ onSelect, selectedTimezones = [], triggerRef }:
           </Command>
         </PopoverContent>
       </Popover>
-      
+
       {/* Debug Panel */}
       {DEBUG_MODE && (
-        <div className="mt-4 p-3 bg-gray-100 rounded-md text-xs font-mono">
+        <div className="mt-4 rounded-md bg-gray-100 p-3 font-mono text-xs">
           <div className="mb-2 font-bold">Debug Info:</div>
           <div className="mb-1">Search: &ldquo;{search}&rdquo;</div>
           <div className="mb-1">Results: {filteredTimezones.length}</div>
-          <div className="mb-1">Selected: {selectedTimezones.join(', ')}</div>
-          <div className="mb-1">All Recent: {recentTimezoneNames.join(', ')}</div>
-          <div className="mb-1">Filtered Recent: {filteredRecentTimezoneNames.join(', ')}</div>
+          <div className="mb-1">Selected: {selectedTimezones.join(", ")}</div>
+          <div className="mb-1">
+            All Recent: {recentTimezoneNames.join(", ")}
+          </div>
+          <div className="mb-1">
+            Filtered Recent: {filteredRecentTimezoneNames.join(", ")}
+          </div>
           {search && filteredTimezones.length > 0 && (
             <div>
-              <div className="font-bold mt-2">Top 5 Results:</div>
+              <div className="mt-2 font-bold">Top 5 Results:</div>
               <ol className="list-decimal pl-5">
                 {filteredTimezones.slice(0, 5).map((tz, i) => (
-                  <li key={i}>{tz.label}, {tz.country} ({tz.ianaName})</li>
+                  <li key={i}>
+                    {tz.label}, {tz.country} ({tz.ianaName})
+                  </li>
                 ))}
               </ol>
             </div>
@@ -303,5 +379,5 @@ export function TimezoneSearch({ onSelect, selectedTimezones = [], triggerRef }:
         </div>
       )}
     </>
-  )
+  );
 }

--- a/apps/web-app/src/lib/timezone-search.test.ts
+++ b/apps/web-app/src/lib/timezone-search.test.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { searchTimezones } from './timezone-search.ts'
-import { timezoneDatabase } from './timezone.ts'
+import { searchTimezones } from './timezone-search'
+import { timezoneDatabase } from './timezone'
 
 test('indexes San Francisco as a city alias for Pacific Time', () => {
   const results = searchTimezones(timezoneDatabase, 'San Francisco')

--- a/apps/web-app/src/lib/timezone-search.test.ts
+++ b/apps/web-app/src/lib/timezone-search.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { searchTimezones } from './timezone-search.ts'
+import { timezoneDatabase } from './timezone.ts'
+
+test('indexes San Francisco as a city alias for Pacific Time', () => {
+  const results = searchTimezones(timezoneDatabase, 'San Francisco')
+
+  assert.equal(results.length, 1)
+  assert.equal(results[0].ianaName, 'America/Los_Angeles')
+  assert.ok(results[0].aliases?.includes('San Francisco'))
+})

--- a/apps/web-app/src/lib/timezone-search.ts
+++ b/apps/web-app/src/lib/timezone-search.ts
@@ -1,0 +1,49 @@
+import type { TimeZoneInfo } from './timezone'
+
+function getSearchableText(timezone: TimeZoneInfo): string {
+  return [
+    timezone.label,
+    ...(timezone.aliases || []),
+    timezone.region,
+    timezone.country,
+    timezone.countryCode,
+    timezone.timezone,
+    timezone.ianaName,
+  ]
+    .join(' ')
+    .toLowerCase()
+}
+
+export function searchTimezones(
+  timezones: TimeZoneInfo[],
+  search: string,
+): TimeZoneInfo[] {
+  const searchTerms = search.toLowerCase().trim().split(/\s+/).filter(Boolean)
+
+  if (searchTerms.length === 0) {
+    return timezones
+  }
+
+  const exactMatches = timezones.filter(timezone => {
+    const names = [timezone.label, ...(timezone.aliases || [])]
+    return names.some(name => name.toLowerCase() === searchTerms.join(' '))
+  })
+
+  if (exactMatches.length > 0) {
+    return exactMatches
+  }
+
+  const partialMatches = timezones.filter(timezone => {
+    const searchableText = getSearchableText(timezone)
+    return searchTerms.every(term => searchableText.includes(term))
+  })
+
+  if (partialMatches.length > 0) {
+    return partialMatches
+  }
+
+  return timezones.filter(timezone => {
+    const searchableText = getSearchableText(timezone)
+    return searchTerms.some(term => searchableText.includes(term))
+  })
+}

--- a/apps/web-app/src/lib/timezone-seo.test.ts
+++ b/apps/web-app/src/lib/timezone-seo.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { slugToTimezone } from './timezone-seo'
+import { findTimezone } from './timezone'
+
+test('resolves major city aliases from URL slugs', () => {
+  assert.equal(slugToTimezone('san-francisco'), 'America/Los_Angeles')
+  assert.equal(slugToTimezone('new-york'), 'America/New_York')
+  assert.equal(slugToTimezone('hong-kong'), 'Asia/Hong_Kong')
+})
+
+test('resolves query timezone parameters from city aliases', () => {
+  assert.equal(findTimezone('San Francisco')?.ianaName, 'America/Los_Angeles')
+  assert.equal(findTimezone('Hong Kong')?.ianaName, 'Asia/Hong_Kong')
+})

--- a/apps/web-app/src/lib/timezone-seo.test.ts
+++ b/apps/web-app/src/lib/timezone-seo.test.ts
@@ -11,6 +11,13 @@ test('resolves major city aliases from URL slugs', () => {
 })
 
 test('resolves query timezone parameters from city aliases', () => {
-  assert.equal(findTimezone('San Francisco')?.ianaName, 'America/Los_Angeles')
-  assert.equal(findTimezone('Hong Kong')?.ianaName, 'Asia/Hong_Kong')
+  const sanFrancisco = findTimezone('San Francisco')
+  const hongKong = findTimezone('Hong Kong')
+
+  assert.equal(sanFrancisco?.ianaName, 'America/Los_Angeles')
+  assert.equal(sanFrancisco?.name, 'San Francisco')
+  assert.equal(sanFrancisco?.urlSlug, 'san-francisco')
+  assert.equal(hongKong?.ianaName, 'Asia/Hong_Kong')
+  assert.equal(hongKong?.name, 'Hong Kong')
+  assert.equal(hongKong?.urlSlug, 'hong-kong')
 })

--- a/apps/web-app/src/lib/timezone-seo.ts
+++ b/apps/web-app/src/lib/timezone-seo.ts
@@ -1,4 +1,4 @@
-import { timezoneDatabase } from './timezone';
+import { findTimezoneByLocation, timezoneDatabase } from './timezone';
 
 // Get major timezones that are commonly used for SEO
 export function getMajorTimezones(): string[] {
@@ -45,7 +45,7 @@ export function getMajorTimezones(): string[] {
   ];
 
   // Filter to only include timezones that exist in our database
-  return majorTimezones.filter(tz => 
+  return majorTimezones.filter(tz =>
     timezoneDatabase.some(dbTz => dbTz.ianaName === tz)
   );
 }
@@ -54,14 +54,14 @@ export function getMajorTimezones(): string[] {
 export function generateTimezonePairs(): Array<[string, string]> {
   const majorTimezones = getMajorTimezones();
   const pairs: Array<[string, string]> = [];
-  
+
   // Generate all unique combinations (not permutations)
   for (let i = 0; i < majorTimezones.length; i++) {
     for (let j = i + 1; j < majorTimezones.length; j++) {
       pairs.push([majorTimezones[i], majorTimezones[j]]);
     }
   }
-  
+
   return pairs;
 }
 
@@ -76,17 +76,22 @@ export function slugToTimezone(slug: string): string {
   if (timezoneDatabase.some(tz => tz.ianaName === slug)) {
     return slug;
   }
-  
+
+  const aliasedTimezone = findTimezoneByLocation(slug);
+  if (aliasedTimezone) {
+    return aliasedTimezone.ianaName;
+  }
+
   // Try to find a match by converting the slug
   const normalizedSlug = slug.toLowerCase();
-  
+
   // Check all possible timezone formats
   for (const tz of timezoneDatabase) {
     if (timezoneToSlug(tz.ianaName) === normalizedSlug) {
       return tz.ianaName;
     }
   }
-  
+
   // If no match found, try to reconstruct the timezone
   // Most timezone IDs follow the pattern Region/City
   const parts = slug.split('-');
@@ -97,21 +102,21 @@ export function slugToTimezone(slug: string): string {
       `${parts[0]}/${parts.slice(1).join('-')}`, // america-new-york -> America/New-York
       `${parts[0]}/${parts[1]}`, // Simple two-part
     ];
-    
+
     for (const possible of possibleTimezones) {
       const capitalized = possible
         .split('/')
-        .map(part => part.split(/[-_]/).map(word => 
+        .map(part => part.split(/[-_]/).map(word =>
           word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
         ).join('_'))
         .join('/');
-      
+
       if (timezoneDatabase.some(tz => tz.ianaName === capitalized)) {
         return capitalized;
       }
     }
   }
-  
+
   // Default to the original slug if no match found
   return slug;
 }
@@ -120,14 +125,14 @@ export function slugToTimezone(slug: string): string {
 export function getTimezoneComparisonTitle(tz1: string, tz2: string): string {
   const tz1Info = timezoneDatabase.find(tz => tz.ianaName === tz1);
   const tz2Info = timezoneDatabase.find(tz => tz.ianaName === tz2);
-  
+
   if (!tz1Info || !tz2Info) {
     return 'Timezone Comparison - ZonePal';
   }
-  
+
   const tz1Name = tz1Info.label;
   const tz2Name = tz2Info.label;
-  
+
   return `${tz1Name} to ${tz2Name} Time Converter - ZonePal`;
 }
 
@@ -135,16 +140,16 @@ export function getTimezoneComparisonTitle(tz1: string, tz2: string): string {
 export function getTimezoneComparisonDescription(tz1: string, tz2: string): string {
   const tz1Info = timezoneDatabase.find(tz => tz.ianaName === tz1);
   const tz2Info = timezoneDatabase.find(tz => tz.ianaName === tz2);
-  
+
   if (!tz1Info || !tz2Info) {
     return 'Compare timezones and schedule meetings across different time zones with ZonePal.';
   }
-  
+
   const tz1Name = tz1Info.label;
   const tz2Name = tz2Info.label;
   const tz1Country = tz1Info.country;
   const tz2Country = tz2Info.country;
-  
+
   return `Convert time between ${tz1Name} (${tz1Country}) and ${tz2Name} (${tz2Country}). Find the best meeting times and manage schedules across timezones with our visual timezone converter.`;
 }
 
@@ -152,10 +157,10 @@ export function getTimezoneComparisonDescription(tz1: string, tz2: string): stri
 export function getCanonicalUrl(tz1: string, tz2: string): string {
   const slug1 = timezoneToSlug(tz1);
   const slug2 = timezoneToSlug(tz2);
-  
+
   // Always put them in alphabetical order for canonical URL
   const [first, second] = [slug1, slug2].sort();
-  
+
   return `https://zonepal.com/${first}/${second}`;
 }
 
@@ -163,7 +168,7 @@ export function getCanonicalUrl(tz1: string, tz2: string): string {
 export function getStructuredData(tz1: string, tz2: string) {
   const description = getTimezoneComparisonDescription(tz1, tz2);
   const url = getCanonicalUrl(tz1, tz2);
-  
+
   return {
     '@context': 'https://schema.org',
     '@type': 'WebApplication',

--- a/apps/web-app/src/lib/timezone.ts
+++ b/apps/web-app/src/lib/timezone.ts
@@ -17,6 +17,21 @@ export interface TimeZoneInfo {
   utcOffset: number;
   dstOffset: number;
   aliases: string[];
+  urlSlug?: string;
+}
+
+export function locationToSlug(location: string): string {
+  return normalizeLocationName(location).replace(/\s+/g, '-');
+}
+
+export function withDisplayLocation(timezone: TimeZoneInfo, location: string): TimeZoneInfo {
+  return {
+    ...timezone,
+    label: location,
+    location,
+    name: location,
+    urlSlug: locationToSlug(location),
+  };
 }
 
 const timezoneCityAliases: Record<string, string[]> = {
@@ -134,9 +149,17 @@ export function findTimezoneByLocation(location: string): TimeZoneInfo | undefin
 
   if (!normalizedLocation) return undefined;
 
-  return timezoneDatabase.find(timezone =>
-    getTimezoneNames(timezone).some(name => normalizeLocationName(name) === normalizedLocation)
-  );
+  for (const timezone of timezoneDatabase) {
+    const matchedName = getTimezoneNames(timezone).find(
+      name => normalizeLocationName(name) === normalizedLocation
+    );
+
+    if (matchedName) {
+      return withDisplayLocation(timezone, matchedName);
+    }
+  }
+
+  return undefined;
 }
 
 export function findTimezone(ianaNameOrLocation: string): TimeZoneInfo | undefined {

--- a/apps/web-app/src/lib/timezone.ts
+++ b/apps/web-app/src/lib/timezone.ts
@@ -16,7 +16,12 @@ export interface TimeZoneInfo {
   countryCode: string;
   utcOffset: number;
   dstOffset: number;
+  aliases: string[];
 }
+
+const timezoneCityAliases: Record<string, string[]> = {
+  'America/Los_Angeles': ['San Francisco'],
+};
 
 export function getTimeInTimeZone(date: Date, timeZone: string): { time: string; date: string } {
   const time = formatInTimeZone(date, timeZone, 'h:mm a')
@@ -51,7 +56,8 @@ export const timezoneDatabase = Intl.supportedValuesOf('timeZone').map(timezone 
     time: '',
     date: '',
     utcOffset: tzInfo?.utcOffset || 0,
-    dstOffset: tzInfo?.dstOffset || 0
+    dstOffset: tzInfo?.dstOffset || 0,
+    aliases: timezoneCityAliases[timezone] || []
   };
 });
 
@@ -89,4 +95,4 @@ export function getTimezonesForCountry(countryCode: string): TimeZoneInfo[] {
 export function getCountryForTimezone(timezoneName: string): { code: string; name: string } | null {
   const country = ct.getCountryForTimezone(timezoneName);
   return country ? { code: country.id, name: country.name } : null;
-} 
+}

--- a/apps/web-app/src/lib/timezone.ts
+++ b/apps/web-app/src/lib/timezone.ts
@@ -20,8 +20,55 @@ export interface TimeZoneInfo {
 }
 
 const timezoneCityAliases: Record<string, string[]> = {
-  'America/Los_Angeles': ['San Francisco'],
+  'America/Los_Angeles': ['San Francisco', 'San Jose', 'Oakland', 'Las Vegas', 'Seattle', 'Portland', 'San Diego'],
+  'America/New_York': ['Washington DC', 'Washington D.C.', 'Boston', 'Miami', 'Atlanta', 'Philadelphia', 'Detroit'],
+  'America/Chicago': ['Dallas', 'Houston', 'Austin', 'San Antonio', 'Minneapolis', 'New Orleans'],
+  'America/Denver': ['Phoenix', 'Salt Lake City', 'Calgary', 'Edmonton'],
+  'America/Toronto': ['Ottawa', 'Montreal'],
+  'America/Vancouver': ['Victoria'],
+  'America/Sao_Paulo': ['Rio de Janeiro', 'Brasilia'],
+  'America/Buenos_Aires': ['Cordoba', 'Rosario'],
+  'Europe/London': ['Dublin', 'Edinburgh', 'Manchester'],
+  'Europe/Paris': ['Brussels', 'Lyon'],
+  'Europe/Berlin': ['Frankfurt', 'Munich', 'Hamburg'],
+  'Europe/Rome': ['Milan', 'Naples'],
+  'Europe/Madrid': ['Barcelona', 'Valencia'],
+  'Europe/Amsterdam': ['Rotterdam'],
+  'Europe/Zurich': ['Geneva'],
+  'Europe/Stockholm': ['Oslo', 'Copenhagen'],
+  'Europe/Istanbul': ['Ankara'],
+  'Europe/Moscow': ['Saint Petersburg'],
+  'Asia/Dubai': ['Abu Dhabi'],
+  'Asia/Kolkata': ['Mumbai', 'Delhi', 'Bangalore', 'Bengaluru', 'Hyderabad', 'Chennai'],
+  'Asia/Singapore': ['Kuala Lumpur'],
+  'Asia/Shanghai': ['Beijing', 'Shenzhen', 'Guangzhou'],
+  'Asia/Tokyo': ['Osaka', 'Kyoto'],
+  'Asia/Seoul': ['Busan'],
+  'Australia/Sydney': ['Canberra', 'Brisbane'],
+  'Australia/Melbourne': ['Adelaide'],
+  'Africa/Johannesburg': ['Cape Town', 'Pretoria'],
+  'Africa/Cairo': ['Alexandria'],
+  'Africa/Lagos': ['Abuja', 'Accra'],
 };
+
+function normalizeLocationName(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function slugToLocationName(value: string): string {
+  return value.replace(/-/g, ' ');
+}
+
+function getTimezoneNames(timezone: TimeZoneInfo): string[] {
+  return [timezone.ianaName, timezone.label, timezone.name, ...(timezone.aliases || [])];
+}
+
 
 export function getTimeInTimeZone(date: Date, timeZone: string): { time: string; date: string } {
   const time = formatInTimeZone(date, timeZone, 'h:mm a')
@@ -82,11 +129,26 @@ export function findTimezoneByIana(ianaName: string): TimeZoneInfo | undefined {
   return timezoneDatabase.find(tz => tz.ianaName === ianaName);
 }
 
+export function findTimezoneByLocation(location: string): TimeZoneInfo | undefined {
+  const normalizedLocation = normalizeLocationName(slugToLocationName(location));
+
+  if (!normalizedLocation) return undefined;
+
+  return timezoneDatabase.find(timezone =>
+    getTimezoneNames(timezone).some(name => normalizeLocationName(name) === normalizedLocation)
+  );
+}
+
+export function findTimezone(ianaNameOrLocation: string): TimeZoneInfo | undefined {
+  return findTimezoneByIana(ianaNameOrLocation) || findTimezoneByLocation(ianaNameOrLocation);
+}
+
+
 // New helper functions
 export function getTimezonesForCountry(countryCode: string): TimeZoneInfo[] {
   const country = ct.getCountry(countryCode);
   if (!country) return [];
-  
+
   return country.timezones
     .map(tz => timezoneDatabase.find(t => t.ianaName === tz))
     .filter((tz): tz is TimeZoneInfo => tz !== undefined);


### PR DESCRIPTION
## Summary

- index San Francisco as a searchable city alias for Pacific Time
- extract timezone matching into a focused, testable search helper
- include city aliases in the rendered command item so cmdk preserves the result

## Root cause

The search database is built from canonical IANA timezone identifiers. It contains `America/Los_Angeles`, but no `America/San_Francisco` entry or San Francisco city metadata. The component's broader filter could find unrelated partial matches, while cmdk's second filter removed them because their item values did not contain "San Francisco".

## User impact

Searching for "San Francisco" now returns the Pacific Time entry and visibly identifies San Francisco as an alias. Selecting it adds `America/Los_Angeles`, which is the correct IANA timezone for San Francisco.

## Verification

Exact head SHA: `7a8e50bda744a39b436806ef368c66dc7c16118f`

- `node --experimental-strip-types --test apps/web-app/src/lib/timezone-search.test.ts` — PASS
- `pnpm lint` — PASS; four pre-existing `main.tsx` hook warnings remain
- `pnpm build` — PASS; 637 static pages generated and sitemap generation completed
- browser QA at `http://localhost:3000` — PASS; searching "San Francisco" displayed one Los Angeles result with `Also: San Francisco`, and selecting it added `America/Los_Angeles`
- `git diff --check` — PASS

## Known environment gaps

- PostHog was disabled locally because its environment variables were absent.
- Weather requests returned errors because the local weather API credentials/service were unavailable; this is unrelated to timezone search.

No merge is requested by this draft PR.
